### PR TITLE
Temp fix for orphaned mixpanel submodule commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "Submodules/vectorboolean"]
 	path = Submodules/vectorboolean
 	url = git@github.com:adamwulf/vectorboolean.git
-[submodule "Submodules/mixpanel"]
-	path = Submodules/mixpanel
-	url = git@github.com:mixpanel/mixpanel-iphone.git
 [submodule "Submodules/sskeychain"]
 	path = Submodules/sskeychain
 	url = git@github.com:adamwulf/sskeychain.git
@@ -46,3 +43,6 @@
 [submodule "Submodules/spacecommander"]
 	path = Submodules/spacecommander
 	url = git@github.com:square/spacecommander.git
+[submodule "Submodules/mixpanel"]
+	path = Submodules/mixpanel
+	url = git@github.com:kloned/mixpanel-578cfe1

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ More gesture videos available on the <a href='http://getlooseleaf.com'>Loose Lea
 First, clone the Loose Leaf repository and initialize all submodules:
 
 ```
-git clone git@github.com:adamwulf/loose-leaf.git
+git clone -b temp_mixpanel_fix git@github.com:adamwulf/loose-leaf.git
 cd loose-leaf
 git submodule update --recursive --init
 ```


### PR DESCRIPTION
This is temporary fix for issue #1867 and it should reside in a separate branch.

**Explanation**
Mixpanel maintainers has made @adamwulf's [commit](https://github.com/mixpanel/mixpanel-iphone/commit/578cfe1f2b143265c86477a3cb787b79ad50a8a4) orphaned due to possible [deleted unmerged branch or forced push over this commit](https://help.github.com/en/articles/commit-exists-on-github-but-not-in-my-local-clone).
Although this commit is not available locally, fortunately it's still available by github's direct [link](https://github.com/mixpanel/mixpanel-iphone/tree/578cfe1f2b143265c86477a3cb787b79ad50a8a4).

**Solution**
1. New [repository](https://github.com/kloned/mixpanel-578cfe1) was created with mixpanel's 578cfe1f2b commit content in it
2. loose-leaf's mixpanel submodule has been modified to point to this new repository
3. Readme was updated accordingly