### PR TITLE
Web server that serves currently active image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "Submodules/spacecommander"]
 	path = Submodules/spacecommander
 	url = git@github.com:square/spacecommander.git
+[submodule "Submodules/CocoaHTTPServer"]
+	path = Submodules/CocoaHTTPServer
+	url = https://github.com/robbiehanson/CocoaHTTPServer.git

--- a/Project/LooseLeaf.xcodeproj/project.pbxproj
+++ b/Project/LooseLeaf.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1F2CF00725332CDE00FA12C4 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6525332CDD00FA12C4 /* DDAbstractDatabaseLogger.m */; };
 		1F2CF00825332CDE00FA12C4 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6625332CDD00FA12C4 /* DDFileLogger.m */; };
 		1F2CF00925332CDE00FA12C4 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6925332CDD00FA12C4 /* GCDAsyncSocket.m */; };
+		1F2CF01E253333FA00FA12C4 /* MMPaperRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CF01D253333FA00FA12C4 /* MMPaperRequest.m */; };
 		6600BAA71B6DE4F400D8B2DB /* new-user-intro.png in Resources */ = {isa = PBXBuildFile; fileRef = 6600BAA61B6DE4F400D8B2DB /* new-user-intro.png */; };
 		66052A0317FA170600A94531 /* MMImmutableScrapsOnPaperState.m in Sources */ = {isa = PBXBuildFile; fileRef = 66052A0217FA170600A94531 /* MMImmutableScrapsOnPaperState.m */; };
 		66066747193A7C1400C985E9 /* UIImage+Memory.m in Sources */ = {isa = PBXBuildFile; fileRef = 66066746193A7C1400C985E9 /* UIImage+Memory.m */; };
@@ -753,6 +754,8 @@
 		1F2CEF6725332CDD00FA12C4 /* DDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDASLLogger.h; sourceTree = "<group>"; };
 		1F2CEF6925332CDD00FA12C4 /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncSocket.m; sourceTree = "<group>"; };
 		1F2CEF6B25332CDD00FA12C4 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncSocket.h; sourceTree = "<group>"; };
+		1F2CF01C253333FA00FA12C4 /* MMPaperRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MMPaperRequest.h; sourceTree = "<group>"; };
+		1F2CF01D253333FA00FA12C4 /* MMPaperRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMPaperRequest.m; sourceTree = "<group>"; };
 		6600BAA61B6DE4F400D8B2DB /* new-user-intro.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "new-user-intro.png"; sourceTree = "<group>"; };
 		66052A0117FA170600A94531 /* MMImmutableScrapsOnPaperState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMImmutableScrapsOnPaperState.h; sourceTree = "<group>"; };
 		66052A0217FA170600A94531 /* MMImmutableScrapsOnPaperState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMImmutableScrapsOnPaperState.m; sourceTree = "<group>"; };
@@ -2573,6 +2576,8 @@
 				662370D91A9E90B200B62F69 /* MMBackgroundedPaperView.m */,
 				66EDE42B19AFE27300A5623B /* MMExportablePaperView.h */,
 				66EDE42C19AFE27300A5623B /* MMExportablePaperView.m */,
+				1F2CF01C253333FA00FA12C4 /* MMPaperRequest.h */,
+				1F2CF01D253333FA00FA12C4 /* MMPaperRequest.m */,
 			);
 			name = MMPaperView;
 			sourceTree = "<group>";
@@ -5263,6 +5268,7 @@
 				66B21A56175AFCA70049F1AF /* MMHandButton.m in Sources */,
 				C5E02A891D99C9FA001F6ED6 /* MMFeedbackButton.m in Sources */,
 				C5D749F420FEF844004F5781 /* MPNSAttributedStringToNSDictionaryValueTransformer.m in Sources */,
+				1F2CF01E253333FA00FA12C4 /* MMPaperRequest.m in Sources */,
 				66B21A6C175E4A5A0049F1AF /* MMSingleStackManager.m in Sources */,
 				669115A81AE8811C00C4FC89 /* MMLoopView.m in Sources */,
 				C5D749D320FEF844004F5781 /* MPUIImageToNSDictionaryValueTransformer.m in Sources */,

--- a/Project/LooseLeaf.xcodeproj/project.pbxproj
+++ b/Project/LooseLeaf.xcodeproj/project.pbxproj
@@ -7,6 +7,32 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F2CEF8A25332CDD00FA12C4 /* HTTPErrorResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6325332CDD00FA12C4 /* HTTPErrorResponse.m */; };
+		1F2CEF8B25332CDD00FA12C4 /* HTTPDataResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6425332CDD00FA12C4 /* HTTPDataResponse.m */; };
+		1F2CEF8C25332CDD00FA12C4 /* HTTPDynamicFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6625332CDD00FA12C4 /* HTTPDynamicFileResponse.m */; };
+		1F2CEF8D25332CDD00FA12C4 /* HTTPFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6725332CDD00FA12C4 /* HTTPFileResponse.m */; };
+		1F2CEF8E25332CDD00FA12C4 /* HTTPAsyncFileResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6825332CDD00FA12C4 /* HTTPAsyncFileResponse.m */; };
+		1F2CEF8F25332CDD00FA12C4 /* HTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6925332CDD00FA12C4 /* HTTPRedirectResponse.m */; };
+		1F2CEF9025332CDE00FA12C4 /* HTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE6F25332CDD00FA12C4 /* HTTPMessage.m */; };
+		1F2CEF9125332CDE00FA12C4 /* HTTPConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7025332CDD00FA12C4 /* HTTPConnection.m */; };
+		1F2CEF9225332CDE00FA12C4 /* WebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7125332CDD00FA12C4 /* WebSocket.m */; };
+		1F2CEF9325332CDE00FA12C4 /* MultipartMessageHeaderField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7625332CDD00FA12C4 /* MultipartMessageHeaderField.m */; };
+		1F2CEF9425332CDE00FA12C4 /* MultipartFormDataParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7725332CDD00FA12C4 /* MultipartFormDataParser.m */; };
+		1F2CEF9525332CDE00FA12C4 /* MultipartMessageHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7825332CDD00FA12C4 /* MultipartMessageHeader.m */; };
+		1F2CEF9625332CDE00FA12C4 /* HTTPAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7A25332CDD00FA12C4 /* HTTPAuthenticationRequest.m */; };
+		1F2CEF9725332CDE00FA12C4 /* DDNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7C25332CDD00FA12C4 /* DDNumber.m */; };
+		1F2CEF9825332CDE00FA12C4 /* DDData.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE7D25332CDD00FA12C4 /* DDData.m */; };
+		1F2CEF9925332CDE00FA12C4 /* DDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE8025332CDD00FA12C4 /* DDRange.m */; };
+		1F2CEF9A25332CDE00FA12C4 /* HTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEE8225332CDD00FA12C4 /* HTTPServer.m */; };
+		1F2CF00025332CDE00FA12C4 /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF5725332CDD00FA12C4 /* DDTTYLogger.m */; };
+		1F2CF00125332CDE00FA12C4 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF5A25332CDD00FA12C4 /* DDASLLogger.m */; };
+		1F2CF00225332CDE00FA12C4 /* ContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF5F25332CDD00FA12C4 /* ContextFilterLogFormatter.m */; };
+		1F2CF00325332CDE00FA12C4 /* DispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6025332CDD00FA12C4 /* DispatchQueueLogFormatter.m */; };
+		1F2CF00425332CDE00FA12C4 /* README.txt in Resources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6125332CDD00FA12C4 /* README.txt */; };
+		1F2CF00525332CDE00FA12C4 /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6225332CDD00FA12C4 /* DDLog.m */; };
+		1F2CF00725332CDE00FA12C4 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6525332CDD00FA12C4 /* DDAbstractDatabaseLogger.m */; };
+		1F2CF00825332CDE00FA12C4 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6625332CDD00FA12C4 /* DDFileLogger.m */; };
+		1F2CF00925332CDE00FA12C4 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2CEF6925332CDD00FA12C4 /* GCDAsyncSocket.m */; };
 		6600BAA71B6DE4F400D8B2DB /* new-user-intro.png in Resources */ = {isa = PBXBuildFile; fileRef = 6600BAA61B6DE4F400D8B2DB /* new-user-intro.png */; };
 		66052A0317FA170600A94531 /* MMImmutableScrapsOnPaperState.m in Sources */ = {isa = PBXBuildFile; fileRef = 66052A0217FA170600A94531 /* MMImmutableScrapsOnPaperState.m */; };
 		66066747193A7C1400C985E9 /* UIImage+Memory.m in Sources */ = {isa = PBXBuildFile; fileRef = 66066746193A7C1400C985E9 /* UIImage+Memory.m */; };
@@ -595,7 +621,6 @@
 		C5D749FC20FEF844004F5781 /* Mixpanel.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D7496F20FEF843004F5781 /* Mixpanel.m */; };
 		C5D749FD20FEF844004F5781 /* MPTweak.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D7497020FEF843004F5781 /* MPTweak.m */; };
 		C5D749FE20FEF844004F5781 /* test_variant.json in Resources */ = {isa = PBXBuildFile; fileRef = C5D7497120FEF843004F5781 /* test_variant.json */; };
-		C5D749FF20FEF844004F5781 /* MixpanelWatchProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D7497320FEF843004F5781 /* MixpanelWatchProperties.m */; };
 		C5D74A0020FEF844004F5781 /* Mixpanel+AutomaticTracks.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D7497820FEF843004F5781 /* Mixpanel+AutomaticTracks.m */; };
 		C5D74A0120FEF844004F5781 /* MPTakeoverNotificationViewController~iphonelandscape.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5D7497920FEF843004F5781 /* MPTakeoverNotificationViewController~iphonelandscape.xib */; };
 		C5D74A0220FEF844004F5781 /* UIApplication+AutomaticTracks.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D7497A20FEF843004F5781 /* UIApplication+AutomaticTracks.m */; };
@@ -675,6 +700,59 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1F2CEE5C25332CDD00FA12C4 /* HTTPConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPConnection.h; sourceTree = "<group>"; };
+		1F2CEE5D25332CDD00FA12C4 /* HTTPLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPLogging.h; sourceTree = "<group>"; };
+		1F2CEE5E25332CDD00FA12C4 /* HTTPMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPMessage.h; sourceTree = "<group>"; };
+		1F2CEE5F25332CDD00FA12C4 /* WebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocket.h; sourceTree = "<group>"; };
+		1F2CEE6025332CDD00FA12C4 /* HTTPAuthenticationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPAuthenticationRequest.h; sourceTree = "<group>"; };
+		1F2CEE6225332CDD00FA12C4 /* HTTPAsyncFileResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPAsyncFileResponse.h; sourceTree = "<group>"; };
+		1F2CEE6325332CDD00FA12C4 /* HTTPErrorResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPErrorResponse.m; sourceTree = "<group>"; };
+		1F2CEE6425332CDD00FA12C4 /* HTTPDataResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPDataResponse.m; sourceTree = "<group>"; };
+		1F2CEE6525332CDD00FA12C4 /* HTTPRedirectResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPRedirectResponse.h; sourceTree = "<group>"; };
+		1F2CEE6625332CDD00FA12C4 /* HTTPDynamicFileResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPDynamicFileResponse.m; sourceTree = "<group>"; };
+		1F2CEE6725332CDD00FA12C4 /* HTTPFileResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPFileResponse.m; sourceTree = "<group>"; };
+		1F2CEE6825332CDD00FA12C4 /* HTTPAsyncFileResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPAsyncFileResponse.m; sourceTree = "<group>"; };
+		1F2CEE6925332CDD00FA12C4 /* HTTPRedirectResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPRedirectResponse.m; sourceTree = "<group>"; };
+		1F2CEE6A25332CDD00FA12C4 /* HTTPDataResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPDataResponse.h; sourceTree = "<group>"; };
+		1F2CEE6B25332CDD00FA12C4 /* HTTPErrorResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPErrorResponse.h; sourceTree = "<group>"; };
+		1F2CEE6C25332CDD00FA12C4 /* HTTPFileResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPFileResponse.h; sourceTree = "<group>"; };
+		1F2CEE6D25332CDD00FA12C4 /* HTTPDynamicFileResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPDynamicFileResponse.h; sourceTree = "<group>"; };
+		1F2CEE6E25332CDD00FA12C4 /* HTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPServer.h; sourceTree = "<group>"; };
+		1F2CEE6F25332CDD00FA12C4 /* HTTPMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPMessage.m; sourceTree = "<group>"; };
+		1F2CEE7025332CDD00FA12C4 /* HTTPConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPConnection.m; sourceTree = "<group>"; };
+		1F2CEE7125332CDD00FA12C4 /* WebSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebSocket.m; sourceTree = "<group>"; };
+		1F2CEE7225332CDD00FA12C4 /* HTTPResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPResponse.h; sourceTree = "<group>"; };
+		1F2CEE7425332CDD00FA12C4 /* MultipartFormDataParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultipartFormDataParser.h; sourceTree = "<group>"; };
+		1F2CEE7525332CDD00FA12C4 /* MultipartMessageHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultipartMessageHeader.h; sourceTree = "<group>"; };
+		1F2CEE7625332CDD00FA12C4 /* MultipartMessageHeaderField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipartMessageHeaderField.m; sourceTree = "<group>"; };
+		1F2CEE7725332CDD00FA12C4 /* MultipartFormDataParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipartFormDataParser.m; sourceTree = "<group>"; };
+		1F2CEE7825332CDD00FA12C4 /* MultipartMessageHeader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipartMessageHeader.m; sourceTree = "<group>"; };
+		1F2CEE7925332CDD00FA12C4 /* MultipartMessageHeaderField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultipartMessageHeaderField.h; sourceTree = "<group>"; };
+		1F2CEE7A25332CDD00FA12C4 /* HTTPAuthenticationRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPAuthenticationRequest.m; sourceTree = "<group>"; };
+		1F2CEE7C25332CDD00FA12C4 /* DDNumber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDNumber.m; sourceTree = "<group>"; };
+		1F2CEE7D25332CDD00FA12C4 /* DDData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDData.m; sourceTree = "<group>"; };
+		1F2CEE7E25332CDD00FA12C4 /* DDRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDRange.h; sourceTree = "<group>"; };
+		1F2CEE7F25332CDD00FA12C4 /* DDNumber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDNumber.h; sourceTree = "<group>"; };
+		1F2CEE8025332CDD00FA12C4 /* DDRange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDRange.m; sourceTree = "<group>"; };
+		1F2CEE8125332CDD00FA12C4 /* DDData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDData.h; sourceTree = "<group>"; };
+		1F2CEE8225332CDD00FA12C4 /* HTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPServer.m; sourceTree = "<group>"; };
+		1F2CEF5725332CDD00FA12C4 /* DDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDTTYLogger.m; sourceTree = "<group>"; };
+		1F2CEF5825332CDD00FA12C4 /* DDLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDLog.h; sourceTree = "<group>"; };
+		1F2CEF5925332CDD00FA12C4 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		1F2CEF5A25332CDD00FA12C4 /* DDASLLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDASLLogger.m; sourceTree = "<group>"; };
+		1F2CEF5B25332CDD00FA12C4 /* DDFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDFileLogger.h; sourceTree = "<group>"; };
+		1F2CEF5D25332CDD00FA12C4 /* ContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		1F2CEF5E25332CDD00FA12C4 /* DispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		1F2CEF5F25332CDD00FA12C4 /* ContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		1F2CEF6025332CDD00FA12C4 /* DispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		1F2CEF6125332CDD00FA12C4 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
+		1F2CEF6225332CDD00FA12C4 /* DDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLog.m; sourceTree = "<group>"; };
+		1F2CEF6425332CDD00FA12C4 /* DDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDTTYLogger.h; sourceTree = "<group>"; };
+		1F2CEF6525332CDD00FA12C4 /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		1F2CEF6625332CDD00FA12C4 /* DDFileLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDFileLogger.m; sourceTree = "<group>"; };
+		1F2CEF6725332CDD00FA12C4 /* DDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDASLLogger.h; sourceTree = "<group>"; };
+		1F2CEF6925332CDD00FA12C4 /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncSocket.m; sourceTree = "<group>"; };
+		1F2CEF6B25332CDD00FA12C4 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncSocket.h; sourceTree = "<group>"; };
 		6600BAA61B6DE4F400D8B2DB /* new-user-intro.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "new-user-intro.png"; sourceTree = "<group>"; };
 		66052A0117FA170600A94531 /* MMImmutableScrapsOnPaperState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMImmutableScrapsOnPaperState.h; sourceTree = "<group>"; };
 		66052A0217FA170600A94531 /* MMImmutableScrapsOnPaperState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMImmutableScrapsOnPaperState.m; sourceTree = "<group>"; };
@@ -1929,6 +2007,131 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F2CEE5A25332CDD00FA12C4 /* CocoaHTTPServer */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEE5B25332CDD00FA12C4 /* Core */,
+				1F2CEF5525332CDD00FA12C4 /* Vendor */,
+			);
+			name = CocoaHTTPServer;
+			path = ../../Submodules/CocoaHTTPServer;
+			sourceTree = "<group>";
+		};
+		1F2CEE5B25332CDD00FA12C4 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEE5C25332CDD00FA12C4 /* HTTPConnection.h */,
+				1F2CEE5D25332CDD00FA12C4 /* HTTPLogging.h */,
+				1F2CEE5E25332CDD00FA12C4 /* HTTPMessage.h */,
+				1F2CEE5F25332CDD00FA12C4 /* WebSocket.h */,
+				1F2CEE6025332CDD00FA12C4 /* HTTPAuthenticationRequest.h */,
+				1F2CEE6125332CDD00FA12C4 /* Responses */,
+				1F2CEE6E25332CDD00FA12C4 /* HTTPServer.h */,
+				1F2CEE6F25332CDD00FA12C4 /* HTTPMessage.m */,
+				1F2CEE7025332CDD00FA12C4 /* HTTPConnection.m */,
+				1F2CEE7125332CDD00FA12C4 /* WebSocket.m */,
+				1F2CEE7225332CDD00FA12C4 /* HTTPResponse.h */,
+				1F2CEE7325332CDD00FA12C4 /* Mime */,
+				1F2CEE7A25332CDD00FA12C4 /* HTTPAuthenticationRequest.m */,
+				1F2CEE7B25332CDD00FA12C4 /* Categories */,
+				1F2CEE8225332CDD00FA12C4 /* HTTPServer.m */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		1F2CEE6125332CDD00FA12C4 /* Responses */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEE6225332CDD00FA12C4 /* HTTPAsyncFileResponse.h */,
+				1F2CEE6325332CDD00FA12C4 /* HTTPErrorResponse.m */,
+				1F2CEE6425332CDD00FA12C4 /* HTTPDataResponse.m */,
+				1F2CEE6525332CDD00FA12C4 /* HTTPRedirectResponse.h */,
+				1F2CEE6625332CDD00FA12C4 /* HTTPDynamicFileResponse.m */,
+				1F2CEE6725332CDD00FA12C4 /* HTTPFileResponse.m */,
+				1F2CEE6825332CDD00FA12C4 /* HTTPAsyncFileResponse.m */,
+				1F2CEE6925332CDD00FA12C4 /* HTTPRedirectResponse.m */,
+				1F2CEE6A25332CDD00FA12C4 /* HTTPDataResponse.h */,
+				1F2CEE6B25332CDD00FA12C4 /* HTTPErrorResponse.h */,
+				1F2CEE6C25332CDD00FA12C4 /* HTTPFileResponse.h */,
+				1F2CEE6D25332CDD00FA12C4 /* HTTPDynamicFileResponse.h */,
+			);
+			path = Responses;
+			sourceTree = "<group>";
+		};
+		1F2CEE7325332CDD00FA12C4 /* Mime */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEE7425332CDD00FA12C4 /* MultipartFormDataParser.h */,
+				1F2CEE7525332CDD00FA12C4 /* MultipartMessageHeader.h */,
+				1F2CEE7625332CDD00FA12C4 /* MultipartMessageHeaderField.m */,
+				1F2CEE7725332CDD00FA12C4 /* MultipartFormDataParser.m */,
+				1F2CEE7825332CDD00FA12C4 /* MultipartMessageHeader.m */,
+				1F2CEE7925332CDD00FA12C4 /* MultipartMessageHeaderField.h */,
+			);
+			path = Mime;
+			sourceTree = "<group>";
+		};
+		1F2CEE7B25332CDD00FA12C4 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEE7C25332CDD00FA12C4 /* DDNumber.m */,
+				1F2CEE7D25332CDD00FA12C4 /* DDData.m */,
+				1F2CEE7E25332CDD00FA12C4 /* DDRange.h */,
+				1F2CEE7F25332CDD00FA12C4 /* DDNumber.h */,
+				1F2CEE8025332CDD00FA12C4 /* DDRange.m */,
+				1F2CEE8125332CDD00FA12C4 /* DDData.h */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		1F2CEF5525332CDD00FA12C4 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEF5625332CDD00FA12C4 /* CocoaLumberjack */,
+				1F2CEF6825332CDD00FA12C4 /* CocoaAsyncSocket */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		1F2CEF5625332CDD00FA12C4 /* CocoaLumberjack */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEF5725332CDD00FA12C4 /* DDTTYLogger.m */,
+				1F2CEF5825332CDD00FA12C4 /* DDLog.h */,
+				1F2CEF5925332CDD00FA12C4 /* DDAbstractDatabaseLogger.h */,
+				1F2CEF5A25332CDD00FA12C4 /* DDASLLogger.m */,
+				1F2CEF5B25332CDD00FA12C4 /* DDFileLogger.h */,
+				1F2CEF5C25332CDD00FA12C4 /* Extensions */,
+				1F2CEF6225332CDD00FA12C4 /* DDLog.m */,
+				1F2CEF6425332CDD00FA12C4 /* DDTTYLogger.h */,
+				1F2CEF6525332CDD00FA12C4 /* DDAbstractDatabaseLogger.m */,
+				1F2CEF6625332CDD00FA12C4 /* DDFileLogger.m */,
+				1F2CEF6725332CDD00FA12C4 /* DDASLLogger.h */,
+			);
+			path = CocoaLumberjack;
+			sourceTree = "<group>";
+		};
+		1F2CEF5C25332CDD00FA12C4 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEF5D25332CDD00FA12C4 /* ContextFilterLogFormatter.h */,
+				1F2CEF5E25332CDD00FA12C4 /* DispatchQueueLogFormatter.h */,
+				1F2CEF5F25332CDD00FA12C4 /* ContextFilterLogFormatter.m */,
+				1F2CEF6025332CDD00FA12C4 /* DispatchQueueLogFormatter.m */,
+				1F2CEF6125332CDD00FA12C4 /* README.txt */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		1F2CEF6825332CDD00FA12C4 /* CocoaAsyncSocket */ = {
+			isa = PBXGroup;
+			children = (
+				1F2CEF6925332CDD00FA12C4 /* GCDAsyncSocket.m */,
+				1F2CEF6B25332CDD00FA12C4 /* GCDAsyncSocket.h */,
+			);
+			path = CocoaAsyncSocket;
+			sourceTree = "<group>";
+		};
 		660E1DA6158FC6120001DA12 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -3322,6 +3525,7 @@
 		66DCFB911581BCEF00B4918C /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				1F2CEE5A25332CDD00FA12C4 /* CocoaHTTPServer */,
 				C5D7492520FEF843004F5781 /* Mixpanel */,
 				6650DD1018F4842E00ADF591 /* Icon Images */,
 				C5DA295C1D7C012500D868EC /* MMMarkdown */,
@@ -4340,7 +4544,7 @@
 				ORGANIZATIONNAME = "Milestone Made, LLC";
 				TargetAttributes = {
 					66DCFB851581BCEF00B4918C = {
-						DevelopmentTeam = MU27A4SCKC;
+						DevelopmentTeam = BGF3GH32LP;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -4490,6 +4694,7 @@
 				C5D749EC20FEF844004F5781 /* MPCloseButton.png in Resources */,
 				C53FCEF91E94C6CD00AA4BEC /* page-template.mp4 in Resources */,
 				66E2240219D633E1000FCA96 /* ios8-settings-camera.png in Resources */,
+				1F2CF00425332CDE00FA12C4 /* README.txt in Resources */,
 				666425C418CBC61200A306C1 /* opencv.license in Resources */,
 				C50DBB031E0B355E0006F58A /* reorder-stack.mp4 in Resources */,
 				C50DBB011E0B338B0006F58A /* export-stack.mp4 in Resources */,
@@ -4628,7 +4833,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "GIT_RELEASE_SHORT_VERSION=`git describe --tags | awk '{split($0,a,\"-\"); print a[1]}'`\nGIT_RELEASE_VERSION=`git rev-list HEAD | wc -l | tr -d ' '`\nVERSION_FOR_SETTINGS=\"${GIT_RELEASE_SHORT_VERSION} (${GIT_RELEASE_VERSION})\"\n\necho \"built products dir/info plist\"\necho \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH%.*}\"\necho \"configuration build dir/contents/settings/Root.plist\"\necho \"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Settings.bundle/Root.plist\"\n\n/usr/libexec/PlistBuddy \"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Settings.bundle/Root.plist\" -c \"set PreferenceSpecifiers:4:DefaultValue $VERSION_FOR_SETTINGS\"";
+			shellScript = "GIT_RELEASE_SHORT_VERSION=`git describe --tags | awk '{split($0,a,\"-\"); print a[1]}'`\nGIT_RELEASE_VERSION=`git rev-list HEAD | wc -l | tr -d ' '`\nVERSION_FOR_SETTINGS=\"${GIT_RELEASE_SHORT_VERSION} (${GIT_RELEASE_VERSION})\"\n\necho \"built products dir/info plist\"\necho \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH%.*}\"\necho \"configuration build dir/contents/settings/Root.plist\"\necho \"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Settings.bundle/Root.plist\"\n\n/usr/libexec/PlistBuddy \"$CONFIGURATION_BUILD_DIR/$CONTENTS_FOLDER_PATH/Settings.bundle/Root.plist\" -c \"set PreferenceSpecifiers:6:DefaultValue $VERSION_FOR_SETTINGS\"\n";
 		};
 		66C0C9D217838C91009491B3 /* Git Version into Info.plist */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4704,6 +4909,7 @@
 				C57559161DD6B65E00670875 /* UIScreen+MMSizing.m in Sources */,
 				66EC2FEC19DD06F6008F2BB6 /* MMPanAndPinchGestureRecognizer.m in Sources */,
 				6652451019957AD600C36609 /* MMTwitterShareItem.m in Sources */,
+				1F2CEF8B25332CDD00FA12C4 /* HTTPDataResponse.m in Sources */,
 				66DCFB971581BCEF00B4918C /* main.m in Sources */,
 				66DCFB9B1581BCEF00B4918C /* MMAppDelegate.m in Sources */,
 				6650DD1718F4849800ADF591 /* MMImageViewButton.m in Sources */,
@@ -4723,6 +4929,7 @@
 				C5D749DA20FEF844004F5781 /* MPEnumDescription.m in Sources */,
 				C5DA29921D7C013A00D868EC /* MMMarkdown.m in Sources */,
 				C5D749DF20FEF844004F5781 /* MPABTestDesignerChangeRequestMessage.m in Sources */,
+				1F2CEF9125332CDE00FA12C4 /* HTTPConnection.m in Sources */,
 				66343C531ABF950E00801962 /* MMNewsletterSignupForm.m in Sources */,
 				6690EF1417CC64630009A0AC /* MMScrapBubbleButton.m in Sources */,
 				6688D1E41A994EA300EB17EC /* MMVideoLoopView.m in Sources */,
@@ -4731,10 +4938,12 @@
 				C5D74A0D20FEF844004F5781 /* MPObjectSerializerContext.m in Sources */,
 				66DCFBCD1582BAED00B4918C /* MMPaperView.m in Sources */,
 				6635BE9619748AA500DFCBBA /* MMUndoRedoBezeledScrapItem.m in Sources */,
+				1F2CEF9825332CDE00FA12C4 /* DDData.m in Sources */,
 				667AE6AB19E5D0C50063DD51 /* MMPageUndoRedoManager+Trash.m in Sources */,
 				660E1DA9158FC6300001DA12 /* NSMutableArray+QueueAdditions.m in Sources */,
 				C5D749FC20FEF844004F5781 /* Mixpanel.m in Sources */,
 				66343C501ABF8CD000801962 /* MMTutorialSidebarButton.m in Sources */,
+				1F2CF00325332CDE00FA12C4 /* DispatchQueueLogFormatter.m in Sources */,
 				665245691996DAB800C36609 /* AFURLResponseSerialization.m in Sources */,
 				66BE6CA219D67BC100A5F650 /* MMPolaroidView.m in Sources */,
 				664FB55B194BAC6A009C1EF9 /* MMCancelableGestureRecognizer.m in Sources */,
@@ -4743,18 +4952,21 @@
 				6699714D17DA5EDB00E81467 /* MMCountableSidebarButton.m in Sources */,
 				C5D74A2620FEF844004F5781 /* MPABTestDesignerDeviceInfoResponseMessage.m in Sources */,
 				C569F4371CD070DE00C19BB0 /* MMBezelStackHolderView.m in Sources */,
+				1F2CEF8C25332CDD00FA12C4 /* HTTPDynamicFileResponse.m in Sources */,
 				C5BFD9FC211A975A0060D4C0 /* MMEmojiOutlineView.m in Sources */,
 				666E254F18F72BCF00C17295 /* MMCameraSidebarContentView.m in Sources */,
 				6652457D1996ECF900C36609 /* MMOpenInAppShareItem.m in Sources */,
 				66F4FB2317D8FE600086E21C /* MMCountBubbleButton.m in Sources */,
 				66343C061ABE45CF00801962 /* MMTutorialButton.m in Sources */,
 				66524521199591FF00C36609 /* MMTencentWeiboShareItem.m in Sources */,
+				1F2CEF8D25332CDD00FA12C4 /* HTTPFileResponse.m in Sources */,
 				C50C0D761C3D077A00DFC079 /* MMMarkerButton.m in Sources */,
 				6664C89E1B27A3890012622E /* MMUntouchableTutorialView.m in Sources */,
 				660E1DAC158FC65C0001DA12 /* NSMutableArray+StackAdditions.m in Sources */,
 				66C3CBE11A29046200D7EE42 /* MMRulerAdjustment.m in Sources */,
 				662280731AAF570A00DAB609 /* MMInboxAssetGroupCell.m in Sources */,
 				C5A5C4A91DFFC91700FD2555 /* MMDecryptPDFStackButton.m in Sources */,
+				1F2CF00025332CDE00FA12C4 /* DDTTYLogger.m in Sources */,
 				6635BE9D19758BFF00DFCBBA /* MMImmutableScrapsInSidebarState.m in Sources */,
 				C5D74A1520FEF844004F5781 /* MPABTestDesignerDeviceInfoRequestMessage.m in Sources */,
 				660E1DB0158FC7DB0001DA12 /* MMPaperIcon.m in Sources */,
@@ -4774,7 +4986,6 @@
 				C53FCEE01E94AA1100AA4BEC /* MMCmGridTemplateView.m in Sources */,
 				C53F97C01E931BA500A1233E /* MMBackgroundStyleContainerView.m in Sources */,
 				663326CD1AB09CD9003915E6 /* MMImageInboxItem.m in Sources */,
-				C5D749FF20FEF844004F5781 /* MixpanelWatchProperties.m in Sources */,
 				C5BAF6821D99FC3A00A86496 /* MMClonePaperStackView.m in Sources */,
 				660E1DB3159028560001DA12 /* NSArray+MapReduce.m in Sources */,
 				C5D749F620FEF844004F5781 /* UIView+MPHelpers.m in Sources */,
@@ -4784,6 +4995,7 @@
 				C5E02A831D99BDF5001F6ED6 /* MMFeedbackViewController.m in Sources */,
 				66524509199575A900C36609 /* MMTextShareItem.m in Sources */,
 				666425BA18CBC20000A306C1 /* MMStretchScrapGestureRecognizer.mm in Sources */,
+				1F2CF00125332CDE00FA12C4 /* DDASLLogger.m in Sources */,
 				664516B9159030FC0012FACA /* Constants.m in Sources */,
 				66A3A6BB1791F18900D8FE1D /* UIDevice+PPI.m in Sources */,
 				66E100F619EC4B67006E7C15 /* MMCameraButton.m in Sources */,
@@ -4796,6 +5008,7 @@
 				66AC8D7D18E754FE00A65036 /* MMAbstractSidebarContentView.m in Sources */,
 				66343C571ABF9FCA00801962 /* MMRoundedButton.m in Sources */,
 				C56883AB1D6D2B3500709FD8 /* MMTrashButton.m in Sources */,
+				1F2CF00525332CDE00FA12C4 /* DDLog.m in Sources */,
 				C599D5701DB6AE6F009035F3 /* (null) in Sources */,
 				C5D74A2D20FEF844004F5781 /* MPCGColorRefToNSStringValueTransformer.m in Sources */,
 				666E254118F5E43600C17295 /* MMPalmTreeButton.m in Sources */,
@@ -4815,8 +5028,10 @@
 				6663CC4A19DFC2280084F9FF /* MMImmutableScrapCollectionState.m in Sources */,
 				C5C298FD1D7BFD2E009AE6BE /* MMReleaseNotesView.m in Sources */,
 				C5D74A1120FEF844004F5781 /* MPMiniNotification.m in Sources */,
+				1F2CF00925332CDE00FA12C4 /* GCDAsyncSocket.m in Sources */,
 				C5D749D520FEF844004F5781 /* UIColor+MPColor.m in Sources */,
 				C5D74A2720FEF844004F5781 /* MPDesignerEventBindingRequestMesssage.m in Sources */,
+				1F2CEF9925332CDE00FA12C4 /* DDRange.m in Sources */,
 				66CE120317D3AD7C00882275 /* MMBounceButton.m in Sources */,
 				C53FCEDD1E94A64C00AA4BEC /* MMMusicTemplateView.m in Sources */,
 				C5D74A0B20FEF844004F5781 /* MPClassDescription.m in Sources */,
@@ -4887,6 +5102,7 @@
 				669329731598EE210033E557 /* UIView+Debug.m in Sources */,
 				6652456A1996DAB800C36609 /* AFURLSessionManager.m in Sources */,
 				66EDA79617CA87F80067BA63 /* MMPanAndPinchScrapGestureRecognizer.m in Sources */,
+				1F2CEF9225332CDE00FA12C4 /* WebSocket.m in Sources */,
 				665C593417BD7C42006DECBF /* Tool.m in Sources */,
 				C57559291DD6ED9700670875 /* UIView+NRTextTransitions.m in Sources */,
 				6688D1E91A99508700EB17EC /* MMTutorialView.m in Sources */,
@@ -4918,18 +5134,22 @@
 				C5BFD9F9211A94EE0060D4C0 /* MMEmojiAssetCell.m in Sources */,
 				66A08E71196B242F00476F99 /* MMUndoRedoMoveScrapItem.m in Sources */,
 				C5F1B2ED1D9B0D6100E0E9A8 /* MMSidebarButtonTapGestureRecognizer.m in Sources */,
+				1F2CF00225332CDE00FA12C4 /* ContextFilterLogFormatter.m in Sources */,
 				66EC2FEF19DD11E0008F2BB6 /* MMJotViewNilState.m in Sources */,
 				C5E654FD1DCBEF6700521894 /* MMConfirmDeleteStackButton.m in Sources */,
 				C504E71A1CFFE55600914A0E /* MMScrapStateUpgrader.m in Sources */,
 				66D0905615F70810004D2CAF /* MMListAddPageButton.m in Sources */,
 				6652457A1996EA6500C36609 /* MMReachabilityManager.m in Sources */,
+				1F2CEF9A25332CDE00FA12C4 /* HTTPServer.m in Sources */,
 				667D98B7192FBF2400625879 /* MMInboxContentView.m in Sources */,
 				66AC8D9218E8A90900A65036 /* MMBufferedImageView.m in Sources */,
 				C5D749D620FEF844004F5781 /* MPABTestDesignerClearResponseMessage.m in Sources */,
 				6690EF1717CC6F710009A0AC /* MMDotView.m in Sources */,
 				C5D74A2820FEF844004F5781 /* MPEventBinding.m in Sources */,
 				66AC8D8618E8902A00A65036 /* ALAssetsGroup+Properties.m in Sources */,
+				1F2CEF8A25332CDD00FA12C4 /* HTTPErrorResponse.m in Sources */,
 				C5F1B2E61D9B0CC500E0E9A8 /* MMPagesInBezelContainerView.m in Sources */,
+				1F2CEF9525332CDE00FA12C4 /* MultipartMessageHeader.m in Sources */,
 				66AC8D8E18E89C9800A65036 /* MMAlbumRowView.m in Sources */,
 				C5D74A2120FEF844004F5781 /* MPTweakStore.m in Sources */,
 				662280771AAF9FFF00DAB609 /* MMAlbumGroupListLayout.m in Sources */,
@@ -4955,6 +5175,7 @@
 				663326BA1AAFE409003915E6 /* MMAbstractShareItem.m in Sources */,
 				6652452A1996B45C00C36609 /* MMPhotoAlbumShareItem.m in Sources */,
 				66B51A2A17AC50F7005B5E09 /* MMBezelInGestureRecognizer.m in Sources */,
+				1F2CEF8E25332CDD00FA12C4 /* HTTPAsyncFileResponse.m in Sources */,
 				C5D74A1920FEF844004F5781 /* MPDesignerTrackMessage.m in Sources */,
 				C50C0D6D1C3CE72D00DFC079 /* MMPaletteButton.m in Sources */,
 				C5D74A2220FEF844004F5781 /* MPBOOLToNSNumberValueTransformer.m in Sources */,
@@ -4980,6 +5201,7 @@
 				66ACECDC19D4C02B000EA792 /* MMDefaultPhotoAlbum.m in Sources */,
 				663EFFF31946D153006E6AF5 /* MMButtonAwareTapGestureRecognizer.m in Sources */,
 				6695B6EC17505FBF0069E61F /* MMEditablePaperView.m in Sources */,
+				1F2CEF9325332CDE00FA12C4 /* MultipartMessageHeaderField.m in Sources */,
 				66A790C019689B810037F01A /* MMScissorResult.m in Sources */,
 				667D98CA19300D0F00625879 /* MMScrapBackgroundView.m in Sources */,
 				661885D418F9AED50016A333 /* MMDarkSidebarButton.m in Sources */,
@@ -5008,6 +5230,7 @@
 				C5D74A1420FEF844004F5781 /* MPAbstractABTestDesignerMessage.m in Sources */,
 				66AC8D7918E7506A00A65036 /* MMImageSidebarContainerView.m in Sources */,
 				C5BFD9F6211A94DB0060D4C0 /* MMEmojiSidebarContentView.m in Sources */,
+				1F2CEF9025332CDE00FA12C4 /* HTTPMessage.m in Sources */,
 				663326CA1AB09BA7003915E6 /* MMInboxImageAlbum.m in Sources */,
 				665245631996DAB800C36609 /* AFHTTPRequestOperationManager.m in Sources */,
 				66AC8D8018E88BCC00A65036 /* MMPhotoManager.m in Sources */,
@@ -5015,6 +5238,7 @@
 				C5D74A2A20FEF844004F5781 /* MPResources.m in Sources */,
 				C5D74A0420FEF844004F5781 /* MPTweakInline.m in Sources */,
 				66A471C217C7DEF200C2A5B6 /* SYShape+Bezier.m in Sources */,
+				1F2CF00825332CDE00FA12C4 /* DDFileLogger.m in Sources */,
 				66B3522517A9D17500AE58AB /* UIGestureRecognizer+GestureDebug.m in Sources */,
 				66E2241919D66F8B000FCA96 /* MMEmptyCollectionViewCell.m in Sources */,
 				C5DA29961D7C013A00D868EC /* MMHTMLParser.m in Sources */,
@@ -5068,6 +5292,7 @@
 				666E254518F60F3E00C17295 /* MMAlbumSidebarContentView.m in Sources */,
 				663326C61AB09881003915E6 /* MMInboxItem.m in Sources */,
 				66510835178DF9D800A7A7DD /* MMRulerToolGestureRecognizer.m in Sources */,
+				1F2CEF9425332CDE00FA12C4 /* MultipartFormDataParser.m in Sources */,
 				C5D749FD20FEF844004F5781 /* MPTweak.m in Sources */,
 				66ACECDF19D4C122000EA792 /* NSArray+IndexSetAdditions.m in Sources */,
 				6610D0981AAA70E90019C2FB /* MMContinuousSwipeGestureRecognizer.m in Sources */,
@@ -5102,6 +5327,7 @@
 				66F4B4B7178B411E00815E55 /* MMLongPressFromListViewGestureRecognizer.m in Sources */,
 				66A471BE17C7DAA000C2A5B6 /* MMScrappedPaperView.m in Sources */,
 				6610D0851AA8F4A20019C2FB /* MMDisplayAsset.m in Sources */,
+				1F2CEF9625332CDE00FA12C4 /* HTTPAuthenticationRequest.m in Sources */,
 				66E1010619ECDD6C006E7C15 /* MMPresentationWindow.m in Sources */,
 				C55B4DC81DDE7EB5001DC9E4 /* MMFullWidthListButton.m in Sources */,
 				C5D749F820FEF844004F5781 /* MPABTestDesignerConnection.m in Sources */,
@@ -5115,14 +5341,17 @@
 				66AE5AA817F4D064009F82B6 /* MMScrapsOnPaperState.m in Sources */,
 				66343C5E1AC06FDA00801962 /* MMLoopIcon.m in Sources */,
 				6634856919DB551B00B5CF2D /* MMTrashIcon.m in Sources */,
+				1F2CF00725332CDE00FA12C4 /* DDAbstractDatabaseLogger.m in Sources */,
 				66CE11F717CFD8A600882275 /* MMScrapPaperStackView.m in Sources */,
 				C50DBAFA1E0B207B0006F58A /* MMCollapseButton.m in Sources */,
 				667AA41F19E33342006549EE /* MMPolaroidsView.m in Sources */,
 				C5D74A1C20FEF844004F5781 /* MPTakeoverNotification.m in Sources */,
+				1F2CEF8F25332CDD00FA12C4 /* HTTPRedirectResponse.m in Sources */,
 				C54168D3211BD01A0060C48D /* UIBezierPath+MMEmoji.m in Sources */,
 				C53DCEC021042943009A848A /* MMShapeAsset.m in Sources */,
 				6612C8851964C0E3003A9575 /* MMPageUndoRedoManager.m in Sources */,
 				C5D74A1A20FEF844004F5781 /* MPNotification.m in Sources */,
+				1F2CEF9725332CDE00FA12C4 /* DDNumber.m in Sources */,
 				66A471C617C7E06B00C2A5B6 /* MMScrapView.m in Sources */,
 				C53FCEEC1E94BC7700AA4BEC /* MMWeekTemplateView.m in Sources */,
 				C504E6EA1CFAA84E00914A0E /* UIColor+RHInterpolationAdditions.m in Sources */,
@@ -5267,6 +5496,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = LooseLeaf/LooseLeaf.entitlements;
+				DEVELOPMENT_TEAM = BGF3GH32LP;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -5288,7 +5518,7 @@
 					"-ObjC++",
 					"-lstdc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.milestonemade.looseleaf;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yihchun.looseleaf;
 				PRODUCT_NAME = LooseLeaf;
 				TARGETED_DEVICE_FAMILY = 2;
 				WRAPPER_EXTENSION = app;
@@ -5301,6 +5531,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_ENTITLEMENTS = LooseLeaf/LooseLeaf.entitlements;
+				DEVELOPMENT_TEAM = BGF3GH32LP;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -5316,7 +5547,7 @@
 					"-ObjC++",
 					"-lstdc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.milestonemade.looseleaf;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yihchun.looseleaf;
 				PRODUCT_NAME = LooseLeaf;
 				TARGETED_DEVICE_FAMILY = 2;
 				WRAPPER_EXTENSION = app;

--- a/Project/LooseLeaf.xcodeproj/project.pbxproj
+++ b/Project/LooseLeaf.xcodeproj/project.pbxproj
@@ -4549,7 +4549,7 @@
 				ORGANIZATIONNAME = "Milestone Made, LLC";
 				TargetAttributes = {
 					66DCFB851581BCEF00B4918C = {
-						DevelopmentTeam = BGF3GH32LP;
+						DevelopmentTeam = MU27A4SCKC;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -5524,7 +5524,7 @@
 					"-ObjC++",
 					"-lstdc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yihchun.looseleaf;
+				PRODUCT_BUNDLE_IDENTIFIER = com.milestonemade.looseleaf;
 				PRODUCT_NAME = LooseLeaf;
 				TARGETED_DEVICE_FAMILY = 2;
 				WRAPPER_EXTENSION = app;
@@ -5553,7 +5553,7 @@
 					"-ObjC++",
 					"-lstdc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yihchun.looseleaf;
+				PRODUCT_BUNDLE_IDENTIFIER = com.milestonemade.looseleaf;
 				PRODUCT_NAME = LooseLeaf;
 				TARGETED_DEVICE_FAMILY = 2;
 				WRAPPER_EXTENSION = app;

--- a/Project/LooseLeaf/CocoaAsyncSocket.license
+++ b/Project/LooseLeaf/CocoaAsyncSocket.license
@@ -1,0 +1,4 @@
+The CocoaAsyncSocket project is under Public Domain license.
+http://code.google.com/p/cocoaasyncsocket/
+
+The AsyncSocket project has been around since 2001 and is used in many applications and frameworks.

--- a/Project/LooseLeaf/CocoaHTTPServer.license
+++ b/Project/LooseLeaf/CocoaHTTPServer.license
@@ -1,0 +1,18 @@
+CocoaHTTPServer Software License Agreement (BSD License)
+
+Copyright (c) 2011, Deusty, LLC
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Neither the name of Deusty nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Deusty, LLC.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Project/LooseLeaf/CocoaLumberjack.license
+++ b/Project/LooseLeaf/CocoaLumberjack.license
@@ -1,0 +1,17 @@
+CocoaLumberjack is under the New BSD License.
+https://github.com/robbiehanson/CocoaLumberjack
+
+BSD 3-Clause License
+
+Copyright (c) 2010-2020, Deusty, LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of Deusty nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission of Deusty, LLC.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Project/LooseLeaf/MMEditablePaperView.h
+++ b/Project/LooseLeaf/MMEditablePaperView.h
@@ -57,6 +57,7 @@
 - (void)setEditable:(BOOL)isEditable;
 - (BOOL)isEditable;
 - (void)cancelCurrentStrokeIfAny;
+- (NSString*)exportAt;
 
 // abstract
 - (void)saveToDisk:(void (^)(BOOL didSaveEdits))onComplete;

--- a/Project/LooseLeaf/MMEditablePaperView.m
+++ b/Project/LooseLeaf/MMEditablePaperView.m
@@ -402,6 +402,9 @@ static int count = 0;
     }
 }
 
+- (NSString*)exportAt {
+   return [self thumbnailPath];
+}
 
 #pragma mark - Ruler Tool
 

--- a/Project/LooseLeaf/MMPaperRequest.h
+++ b/Project/LooseLeaf/MMPaperRequest.h
@@ -1,0 +1,17 @@
+//
+//  MMPaperRequest.h
+//  LooseLeaf
+//
+//  Created by Yih-Chun Hu on 10/11/20.
+//  Copyright © 2020 Milestone Made, LLC. All rights reserved.
+//
+
+#import "HTTPConnection.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MMPaperRequest : HTTPConnection
+- (NSObject<HTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Project/LooseLeaf/MMPaperRequest.m
+++ b/Project/LooseLeaf/MMPaperRequest.m
@@ -1,0 +1,42 @@
+//
+//  MMPaperRequest.m
+//  LooseLeaf
+//
+//  Created by Yih-Chun Hu on 10/11/20.
+//  Copyright © 2020 Milestone Made, LLC. All rights reserved.
+//
+
+#import "MMPaperRequest.h"
+#import "HTTPLogging.h"
+#import "HTTPServer.h"
+#import "HTTPConnection.h"
+#import "HTTPMessage.h"
+#import "HTTPResponse.h"
+#import "HTTPAuthenticationRequest.h"
+#import "HTTPFileResponse.h"
+#import "HTTPAsyncFileResponse.h"
+#import "MMPageCacheManager.h"
+
+static const int httpLogLevel = HTTP_LOG_LEVEL_WARN;
+
+@implementation MMPaperRequest
+- (NSObject<HTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+{
+    HTTPLogTrace();
+
+    // Override me to provide custom responses.
+
+    NSString *filePath = [self filePathForURI:path allowDirectory:NO];
+    if ([path isEqualToString:@"/"]) {
+        if ([MMPageCacheManager sharedInstance].currentEditablePage)
+            filePath = [[MMPageCacheManager sharedInstance].currentEditablePage exportAt];
+    }
+    BOOL isDir = NO;
+    if (filePath && [[NSFileManager defaultManager] fileExistsAtPath:filePath isDirectory:&isDir] && !isDir) {
+        return [[HTTPFileResponse alloc] initWithFilePath:filePath forConnection:self];
+     }
+
+     return nil;
+}
+
+@end

--- a/Project/LooseLeaf/Settings.bundle/Root.plist
+++ b/Project/LooseLeaf/Settings.bundle/Root.plist
@@ -7,6 +7,22 @@
 	<key>PreferenceSpecifiers</key>
 	<array>
 		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Web Server Options</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Enable Web Server</string>
+			<key>Key</key>
+			<string>enableHTTP</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
 			<key>FooterText</key>
 			<string>Thanks</string>
 			<key>Type</key>


### PR DESCRIPTION
Providing off-iPad access to the image currently being edited has several use cases, including streaming and recording. I've integrated CocoaHTTPServer in a fairly minimal way, such that accessing the iPad at port 8088 gives access to the page currently being edited, and other pages can be accessed through their location in the filesystem. Since not everyone wants to share their sketches on the local network, so this server is off by default and can be enabled through a setting in Preferences.